### PR TITLE
217: fix iOS app by removing OneSignal

### DIFF
--- a/gtubt/android/app/build.gradle
+++ b/gtubt/android/app/build.gradle
@@ -25,13 +25,8 @@ buildscript {
     repositories {
         maven { url 'https://plugins.gradle.org/m2/' } // Gradle Plugin Portal
     }
-    dependencies {
-        // OneSignal-Gradle-Plugin
-        classpath 'gradle.plugin.com.onesignal:onesignal-gradle-plugin:[0.12.6, 0.99.99]'
-    }
 }
 
-apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'com.google.gms.google-services'

--- a/gtubt/lib/main.dart
+++ b/gtubt/lib/main.dart
@@ -7,7 +7,6 @@ import 'package:bloc/bloc.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-// import 'package:onesignal_flutter/onesignal_flutter.dart';
 
 import 'ui/blocs/page_bloc/bloc.dart';
 import 'ui/routes.dart';
@@ -22,12 +21,6 @@ void main() async {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    // OneSignal.shared.init("3f4bf8af-bd07-4353-bdb9-ed92a96908aa", iOSSettings: {
-    //   OSiOSSettings.autoPrompt: false,
-    //   OSiOSSettings.inAppLaunchUrl: true
-    // });
-    // OneSignal.shared
-    //     .setInFocusDisplayType(OSNotificationDisplayType.notification);
     return MultiBlocProvider(
       providers: [
         BlocProvider<AuthenticationBloc>(

--- a/gtubt/lib/main.dart
+++ b/gtubt/lib/main.dart
@@ -7,7 +7,7 @@ import 'package:bloc/bloc.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:onesignal_flutter/onesignal_flutter.dart';
+// import 'package:onesignal_flutter/onesignal_flutter.dart';
 
 import 'ui/blocs/page_bloc/bloc.dart';
 import 'ui/routes.dart';
@@ -22,12 +22,12 @@ void main() async {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    OneSignal.shared.init("3f4bf8af-bd07-4353-bdb9-ed92a96908aa", iOSSettings: {
-      OSiOSSettings.autoPrompt: false,
-      OSiOSSettings.inAppLaunchUrl: true
-    });
-    OneSignal.shared
-        .setInFocusDisplayType(OSNotificationDisplayType.notification);
+    // OneSignal.shared.init("3f4bf8af-bd07-4353-bdb9-ed92a96908aa", iOSSettings: {
+    //   OSiOSSettings.autoPrompt: false,
+    //   OSiOSSettings.inAppLaunchUrl: true
+    // });
+    // OneSignal.shared
+    //     .setInFocusDisplayType(OSNotificationDisplayType.notification);
     return MultiBlocProvider(
       providers: [
         BlocProvider<AuthenticationBloc>(

--- a/gtubt/pubspec.yaml
+++ b/gtubt/pubspec.yaml
@@ -10,7 +10,6 @@ dependencies:
   flutter_bloc: 3.2.0
   equatable: ^1.1.0
   built_value: 6.7.1
-  onesignal_flutter: ^2.6.1
   json_annotation:
   http: ^0.12.1
   flutter:


### PR DESCRIPTION
## What does this PR do?
* Removes OneSignal application wide since it was causing problems with iOS app and wasn't really being used.
* Confirms iOS app is working as expected after just adding GoogleService plist file.